### PR TITLE
Implemented landing page redesign with split layout and OAuth branding

### DIFF
--- a/frontend/app/signin.tsx
+++ b/frontend/app/signin.tsx
@@ -73,13 +73,14 @@ export default function SignInScreen() {
 const styles = StyleSheet.create({
   page: {
     flex: 1,
+    height: '100%',
     flexDirection: 'row',
     backgroundColor: '#fff',
   },
   leftPanel: {
     width: '50%',
     backgroundColor: Colors.light.background,
-    minHeight: '100%',
+    height: '100%',
     padding: 32,
     alignItems: 'center',
     justifyContent: 'center',
@@ -112,7 +113,8 @@ const styles = StyleSheet.create({
   },
   previewCard: {
     width: '100%',
-    height: '66%',
+    height: '58%',
+    maxHeight: 560,
     borderRadius: 24,
     overflow: 'hidden',
     shadowColor: '#000',
@@ -128,7 +130,7 @@ const styles = StyleSheet.create({
   rightPanel: {
     width: '50%',
     backgroundColor: '#fff',
-    minHeight: '100%',
+    height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
     padding: 32,

--- a/frontend/app/signin.tsx
+++ b/frontend/app/signin.tsx
@@ -1,55 +1,173 @@
-import { View, Text, Pressable, Linking } from 'react-native';
-import { useRouter } from 'expo-router';
+import { View, Text, Pressable, Linking, StyleSheet, Image } from 'react-native';
 import { globalStyles } from '@/styles/globalStyle';
-import Header from '@/components/signInHeader';
 import { Stack } from 'expo-router';
 import { API_BASE_URL } from '@/utils/api';
+import { Colors } from '@/constants/theme';
+import { FontAwesome } from '@expo/vector-icons';
 
 export default function SignInScreen() {
-  const router = useRouter();
-
   const githubAuthUrl = `${API_BASE_URL}/oauth2/authorization/github`;
   const googleAuthUrl = `${API_BASE_URL}/oauth2/authorization/google`;
 
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <Header />
-      <View style={globalStyles.container}>
-        <Text style={globalStyles.title}>Sign in to Whiskr</Text>
+      <View style={styles.page}>
+        <View style={styles.leftPanel}>
+          <View style={styles.leftPanelInner}>
+            <View style={styles.brandContent}>
+              <Text style={styles.brandTitle}>Whiskr</Text>
+              <Text style={styles.tagline}>A home for your cats on the internet.</Text>
+            </View>
 
-        {/* GitHub Login */}
-        <Pressable
-          onPress={() => Linking.openURL(githubAuthUrl)}
-          style={({ pressed }) => [
-            globalStyles.button,
-            { opacity: pressed ? 0.7 : 1 },
-          ]}
-        >
-          <Text style={globalStyles.buttonText}>Sign in with GitHub</Text>
-        </Pressable>
+            <View style={styles.previewCard}>
+              <Image
+                source={{
+                  uri: 'https://images.unsplash.com/photo-1511044568932-338cba0ad803?auto=format&fit=crop&w=1200&q=80',
+                }}
+                style={styles.previewImage}
+                resizeMode="cover"
+              />
+            </View>
+          </View>
+        </View>
 
-        {/* Google Login */}
-        <Pressable
-          onPress={() => Linking.openURL(googleAuthUrl)}
-          style={({ pressed }) => [
-            globalStyles.button,
-            { opacity: pressed ? 0.7 : 1, marginTop: 12 },
-          ]}
-        >
-          <Text style={globalStyles.buttonText}>Sign in with Google</Text>
-        </Pressable>
+        <View style={styles.rightPanel}>
+          <View style={styles.formContainer}>
+            <Text style={globalStyles.title}>Sign in to Whiskr</Text>
 
+            <Pressable
+              onPress={() => Linking.openURL(googleAuthUrl)}
+              style={({ pressed }) => [
+                styles.buttonBase,
+                styles.primaryButton,
+                { opacity: pressed ? 0.75 : 1 },
+              ]}
+            >
+              <View style={styles.buttonContent}>
+                <FontAwesome name="google" size={16} color="#fff" />
+                <Text style={styles.primaryButtonText}>Sign in with Google</Text>
+              </View>
+            </Pressable>
 
-
-        <Text style={{ marginTop: 12, color: '#666' }}>
-          You can still browse cats without signing in.
-        </Text>
+            <Pressable
+              onPress={() => Linking.openURL(githubAuthUrl)}
+              style={({ pressed }) => [
+                styles.buttonBase,
+                styles.secondaryButton,
+                { opacity: pressed ? 0.75 : 1 },
+              ]}
+            >
+              <View style={styles.buttonContent}>
+                <FontAwesome name="github" size={16} color={Colors.light.background} />
+                <Text style={styles.secondaryButtonText}>Sign in with GitHub</Text>
+              </View>
+            </Pressable>
+          </View>
+        </View>
       </View>
     </>
   );
 }
 
-
-
-
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: '#fff',
+  },
+  leftPanel: {
+    width: '50%',
+    backgroundColor: Colors.light.background,
+    minHeight: '100%',
+    padding: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  leftPanelInner: {
+    width: '100%',
+    maxWidth: 520,
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  brandContent: {
+    width: '100%',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 24,
+  },
+  brandTitle: {
+    fontSize: 56,
+    fontWeight: '700',
+    color: '#fff',
+    letterSpacing: 0.6,
+  },
+  tagline: {
+    color: '#fff',
+    fontSize: 18,
+    lineHeight: 24,
+    maxWidth: 380,
+    textAlign: 'center',
+  },
+  previewCard: {
+    width: '100%',
+    height: '66%',
+    borderRadius: 24,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 3,
+  },
+  previewImage: {
+    width: '100%',
+    height: '100%',
+  },
+  rightPanel: {
+    width: '50%',
+    backgroundColor: '#fff',
+    minHeight: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  formContainer: {
+    width: '100%',
+    maxWidth: 380,
+    alignSelf: 'center',
+  },
+  buttonBase: {
+    borderRadius: 999,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    marginTop: 16,
+  },
+  buttonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+  },
+  primaryButton: {
+    backgroundColor: Colors.light.background,
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  secondaryButton: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: Colors.light.background,
+  },
+  secondaryButtonText: {
+    color: Colors.light.background,
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+});

--- a/frontend/constants/theme.ts
+++ b/frontend/constants/theme.ts
@@ -5,13 +5,14 @@
 
 import { Platform } from 'react-native';
 
-const tintColorLight = '#0a7ea4';
+const brandPrimary = '#4a7fa5';
+const tintColorLight = brandPrimary;
 const tintColorDark = '#fff';
 
 export const Colors = {
   light: {
     text: '#11181C',
-    background: '#417aa9ff',
+    background: brandPrimary,
     tint: tintColorLight,
     icon: '#687076',
     tabIconDefault: '#687076',
@@ -19,7 +20,7 @@ export const Colors = {
   },
   dark: {
     text: '#ECEDEE',
-    background: '#417aa9ff',
+    background: brandPrimary,
     tint: tintColorDark,
     icon: '#9BA1A6',
     tabIconDefault: '#9BA1A6',


### PR DESCRIPTION
  ## Summary

  Addresses Issue #15

  Implements the Whiskr landing/sign-in page redesign from the PRD, including the fixed two-column layout, branded visual panel, centered sign-in form, and provider-branded OAuth buttons.

  ## What changed

  - Reworked app/signin.tsx into a fixed 50/50 split layout:
      - Left panel: steel-blue brand area with centered Whiskr heading, tagline, and decorative cat image card
      - Right panel: pure-white panel with centered sign-in content
  - Kept OAuth-only sign-in flow and wiring intact:
      - Sign in with Google -> Google auth URL
      - Sign in with GitHub -> GitHub auth URL
  - Added provider logos to sign-in buttons:
      - Google icon on Google button
      - GitHub icon on GitHub button
  - Removed guest-browsing messaging from the landing page
  - Hid header on the landing page for a cleaner first impression